### PR TITLE
Update global args to be lists rather than strings

### DIFF
--- a/R/global_r_plugin.vim
+++ b/R/global_r_plugin.vim
@@ -46,7 +46,7 @@ function SetExeCmd()
     if exists("g:R_exe") && exists("g:R_quit")
         let b:rplugin_R = g:R_exe
         if exists("g:R_args")
-            let b:rplugin_r_args = join(g:R_args)
+            let b:rplugin_r_args = g:R_args
         else
             let b:rplugin_r_args = " "
         endif
@@ -54,28 +54,28 @@ function SetExeCmd()
         let b:SourceLines = function("SourceNotDefined")
     elseif &filetype == "julia"
         let b:rplugin_R = "julia"
-        let b:rplugin_r_args = " "
+        let b:rplugin_r_args = [" "]
         let b:quit_command = "quit()"
         let b:SourceLines = function("JuliaSourceLines")
         call RCreateMaps("ni", '<Plug>RSendFile',     'aa', ':call JuliaSourceLines(getline(1, "$"), "silent")')
     elseif &filetype == "python"
         let b:rplugin_R = "python"
-        let b:rplugin_r_args = " "
+        let b:rplugin_r_args = [" "]
         let b:quit_command = "quit()"
         let b:SourceLines = function("SourceNotDefined")
     elseif &filetype == "haskell"
         let b:rplugin_R = "ghci"
-        let b:rplugin_r_args = " "
+        let b:rplugin_r_args = [" "]
         let b:quit_command = ":quit"
         let b:SourceLines = function("SourceNotDefined")
     elseif &filetype == "ruby"
         let b:rplugin_R = "irb"
-        let b:rplugin_r_args = " "
+        let b:rplugin_r_args = [" "]
         let b:quit_command = "quit"
         let b:SourceLines = function("SourceNotDefined")
     elseif &filetype == "lisp"
         let b:rplugin_R = "clisp"
-        let b:rplugin_r_args = " "
+        let b:rplugin_r_args = [" "]
         let b:quit_command = "(quit)"
         let b:SourceLines = function("SourceNotDefined")
     endif


### PR DESCRIPTION
I think at some point the execution command arguments changed from needing to be provided as strings to a list of strings.

Also, I have a question on the topic of using the plugin as a global plugin.  When using, say, python, I obviously, don't need nvimcom to load.  A while ago, we could skip this waiting by using an option like `let vimrplugin_vimcom_wait = -1`.  That is, something negative.  This doesn't seem to be supported any longer.  Any particular reason?  Could we re-implement it?  Or do you want to try to do something smarter; for example if `R_exe` is set, don't call the `WaitVimComStart()` function? 