### PR TITLE
Fixes #14 regular expression to identify triple back-ticks too greedy

### DIFF
--- a/R/common_global.vim
+++ b/R/common_global.vim
@@ -1132,7 +1132,7 @@ function RSourceLines(...)
         let lines = map(copy(lines), 'substitute(v:val, "^\\.\\. \\?", "", "")')
     endif
     if &filetype == "rmd"
-        let lines = map(copy(lines), 'substitute(v:val, "^\\`\\`\\?", "", "")')
+        let lines = map(copy(lines), 'substitute(v:val, "^(\\`\\`)\\?", "", "")')
     endif
     if !g:R_commented_lines
         let newlines = []
@@ -1502,7 +1502,7 @@ function SendLineToR(godown)
             call KnitChild(line, a:godown)
             return
         endif
-        let line = substitute(line, "^\\`\\`\\?", "", "")
+        let line = substitute(line, "^(\\`\\`)\\?", "", "")
         if RmdIsInRCode(1) == 0
             return
         endif


### PR DESCRIPTION
Note that the lines above looking for double dots (e.g. line 1132)

    let lines = map(copy(lines), 'substitute(v:val, "^\\.\\. \\?", "", "")')

are left unchanged, simply because I do not know yet what the double
dots would represent in markdown. But a similar issue might occure there
is someone had a variable name starting with a dot (not common style,
but allowed in R).