### PR TITLE
Don't jump to R buffer if not on tab

### DIFF
--- a/R/nvimbuffer.vim
+++ b/R/nvimbuffer.vim
@@ -46,7 +46,7 @@ function SendCmdToR_Neovim(...)
         endif
 
         " Update the width, if necessary
-        if g:R_setwidth
+        if g:R_setwidth && len(filter(tabpagebuflist(), "v:val =~ bufnr(g:rplugin_R_bufname)")) >= 1
             call ExeOnRTerm("let s:rwnwdth = winwidth(0)")
             if s:rwnwdth != g:rplugin_R_width && s:rwnwdth != -1 && s:rwnwdth > 10 && s:rwnwdth < 999
                 let g:rplugin_R_width = s:rwnwdth


### PR DESCRIPTION
On nvim, I run R in an nvim buffer.  Sometimes, I hide or put the R buffer onto another tab and still send lines of code.  However, if the R buffer is hidden or on another tab and a line of code is sent and setwidth is on, then a new split is created for the R buffer.  This change prevents the creation of a new split for the R buffer by not doing setwidth if the R buffer is not on the current tab.

I thought a better way would be to eschew the ExeOnRTerm call (which I believe is the source of the problem) and just run something like

```
let s:rwnwdth = windwidth(get_win_nr_function(g:rplugin_R_bufname))
```

But I can't seem to find a `get_win_nr_function()`
