### PR TITLE
fix heuristic to detect if a tmux split is possible

### DIFF
--- a/R/common_global.vim
+++ b/R/common_global.vim
@@ -2953,7 +2953,7 @@ if has("win32")
     let g:R_in_buffer = 0
 endif
 
-if has("gui_running") || g:R_applescript || g:R_in_buffer || $TMUX == "" || has("gui_running")
+if (has("gui_running") && $NVIM_TUI_ENABLE_TRUE_COLOR != "1") || g:R_applescript || g:R_in_buffer || $TMUX == ""
     let g:R_tmux_split = 0
 endif
 


### PR DESCRIPTION
When using neovim with true color by setting `$NVIM_TUI_ENABLE_TRUE_COLOR=1`, `has("gui_running")` reports 1 which breaks the heuristic to determine if a tmux split is possible.