### PR TITLE
Jump to previous window not previous buffer

### DIFF
--- a/R/nvimbuffer.vim
+++ b/R/nvimbuffer.vim
@@ -1,14 +1,11 @@
 " This file contains code used only when R run in Neovim buffer
 
 function ExeOnRTerm(cmd)
-    let curbuf = bufname("%")
-    let savesb = &switchbuf
-    set switchbuf=useopen
+    let curwin = winnr()
     exe 'sb ' . g:rplugin_R_bufname
     exe a:cmd
     call cursor("$", 1)
-    exe 'sb ' . curbuf
-    exe 'set switchbuf=' . savesb
+    exe curwin . 'wincmd w'
 endfunction
 
 function SendCmdToR_Neovim(...)


### PR DESCRIPTION
The ExeOnRTerm function jumps to the term buffer running R and then back to the previous buffer.  However, if one has the same buffer open in multiple windows, ExeOnRTerm jumps back to the first window that contains that buffer.  It makes more sense to jump to the window that the user was previously in rather than just the first window that contains the buffer.

This simple patch should switch the user back to the previous window.   I also don't think that we need to worry about the switchbuf variable anymore, but please correct me if I am wrong.