### PR TITLE
Ignoring dbus, etc. warning messages when checking Zathura version

### DIFF
--- a/R/common_global.vim
+++ b/R/common_global.vim
@@ -2130,7 +2130,7 @@ function RSetPDFViewer()
     if !has("win32") && !g:rplugin_is_darwin
         if g:rplugin_pdfviewer == "zathura"
             if executable("zathura")
-                let vv = split(system("zathura --version"))[1]
+                let vv = split(system("zathura --version 2>/dev/null"))[1]
                 if vv < '0.3.1'
                     call RWarningMsgInp("Zathura version must be >= 0.3.1")
                 endif


### PR DESCRIPTION
Fixes issue preventing zathura version check from failing when warning messages are printed, e.g.:

```
$ zathura --version            

** (zathura:9061): WARNING **: Couldn't connect to accessibility bus: Failed to connect to socket /tmp/dbus-fDiIqj367q: Connection refused
zathura 0.3.5
(plugin) pdf-poppler (0.2.6) (/usr/lib/zathura/pdf.so)
```
