### PR TITLE
Add autovsplit function

### DIFF
--- a/R/nvimbuffer.vim
+++ b/R/nvimbuffer.vim
@@ -85,6 +85,13 @@ function StartR_Neovim()
     let objbrttl = b:objbrtitle
     let curbufnm = bufname("%")
     set switchbuf=useopen
+    if g:R_autovsplit
+        if (winwidth(0) * 0.5) > g:R_rconsole_width
+            let g:R_vsplit = 1
+        else
+            let g:R_vsplit = 0
+        endif
+    endif
     if g:R_vsplit
         if g:R_rconsole_width > 16 && g:R_rconsole_width < (winwidth(0) - 17)
             silent exe "belowright " . g:R_rconsole_width . "vnew"

--- a/doc/Nvim-R.txt
+++ b/doc/Nvim-R.txt
@@ -862,7 +862,7 @@ Vim and R at the end of
 |R_notmuxconf|        Don't use a specially built Tmux config file
 |R_rconsole_height|   The number of lines of R Console
 |R_vsplit|            Split the window vertically when starting R
-R_autovsplit	    Split vertically if window is wide enough, otherwise split horizontally
+|R_autovsplit|	    Split vertically if window is wide enough, otherwise split horizontally
 |R_rconsole_width|    The number of columns of R Console
 |R_applescript|       Use osascript in Mac OS X to run R.app
 |RStudio_cmd|         Run RStudio instead of R.

--- a/doc/Nvim-R.txt
+++ b/doc/Nvim-R.txt
@@ -862,6 +862,7 @@ Vim and R at the end of
 |R_notmuxconf|        Don't use a specially built Tmux config file
 |R_rconsole_height|   The number of lines of R Console
 |R_vsplit|            Split the window vertically when starting R
+R_autovsplit	    Split vertically if window is wide enough, otherwise split horizontally
 |R_rconsole_width|    The number of columns of R Console
 |R_applescript|       Use osascript in Mac OS X to run R.app
 |RStudio_cmd|         Run RStudio instead of R.
@@ -2749,7 +2750,7 @@ step-by-step procedure to run Nvim-R remotely:
 								 *Nvim-R-news*
 10. News~
 
-0.9.8 (2017-01-14)
+0.9.8 (2017-02-03)
 
  * Minor bug fixes.
  * New commands: \dt and \pt


### PR DESCRIPTION
Vertical splits are nice for wide windows, but can become a nuisance if the window is too small horizontally. This introduces an option, `R_autovsplit` to split the window vertically only if the current window size is at least twice as large as `R_rconsole_width` and split horizontally otherwise.