### PR TITLE
Add R_wait_reply option

### DIFF
--- a/R/common_global.vim
+++ b/R/common_global.vim
@@ -141,7 +141,7 @@ function ReadEvalReply()
     let reply = "No reply"
     let haswaitwarn = 0
     let ii = 0
-    while ii < 20
+    while ii < g:R_wait_reply * 10
         sleep 100m
         if filereadable($NVIMR_TMPDIR . "/eval_reply")
             let tmp = readfile($NVIMR_TMPDIR . "/eval_reply")
@@ -3170,6 +3170,7 @@ call RSetDefaultValue("g:R_tmux_split",        0)
 call RSetDefaultValue("g:R_esc_term",          1)
 call RSetDefaultValue("g:R_close_term",        1)
 call RSetDefaultValue("g:R_wait",             60)
+call RSetDefaultValue("g:R_wait_reply",        2)
 call RSetDefaultValue("g:R_show_args",         0)
 call RSetDefaultValue("g:R_never_unmake_menu", 0)
 call RSetDefaultValue("g:R_insert_mode_cmds",  0)

--- a/doc/Nvim-R.txt
+++ b/doc/Nvim-R.txt
@@ -888,6 +888,7 @@ Vim and R at the end of
 |R_show_args|         Show extra information during omnicompletion
 |R_args_in_stline|    Set 'statusline' to function arguments
 |R_wait|              Time to wait for nvimcom loading
+|R_wait_reply|        Time to wait for R reply
 |R_nvim_wd|           Start R in Vim's working directory
 |R_after_start|       System command to execute after R startup
 |R_user_maps_only|    Only set user specified key bindings
@@ -1666,6 +1667,20 @@ nvimcom. If 60 seconds are not enough to your R startup, then set a higher
 value for the variable in your |vimrc|. Example:
 >
    let R_wait = 100
+<
+
+------------------------------------------------------------------------------
+								*R_wait_reply*
+6.29. Time to wait for R reply~
+
+By default Nvim-R asynchronously waits 2 seconds for R to reply after a
+command is issued.  In some cases it might be desirable to extend this period
+to accommodate for commands with long execution times, e.g. when using
+|Rinsert|.  You can set the amount of time NVim-R waits for R to reply (in
+seconds) by setting a different value for `R_wait_reply` (in seconds) in your
+|vimrc|.  Example:
+>
+   let R_wait_reply = 5
 <
 
 ------------------------------------------------------------------------------

--- a/doc/Nvim-R.txt
+++ b/doc/Nvim-R.txt
@@ -1673,12 +1673,11 @@ value for the variable in your |vimrc|. Example:
 								*R_wait_reply*
 6.29. Time to wait for R reply~
 
-By default Nvim-R asynchronously waits 2 seconds for R to reply after a
-command is issued.  In some cases it might be desirable to extend this period
-to accommodate for commands with long execution times, e.g. when using
-|Rinsert|.  You can set the amount of time NVim-R waits for R to reply (in
-seconds) by setting a different value for `R_wait_reply` (in seconds) in your
-|vimrc|.  Example:
+By default Nvim-R waits 2 seconds for R to reply after a command is issued.
+In some cases it might be desirable to extend this period to accommodate for
+commands with long execution times, e.g. when using |Rinsert|.  You can set
+the amount of time NVim-R waits for R to reply (in seconds) by setting a
+different value for `R_wait_reply` (in seconds) in your |vimrc|.  Example:
 >
    let R_wait_reply = 5
 <


### PR DESCRIPTION
When using `:RInsert` to insert the output of a long (i.e. time-consuming) command, I always got the "No reply" warning and the output wouldn't be inserted, even if the command ran perfectly.  So, I decided to make the "waiting time" variable and added an option for it (which probably could have a better name). I also wrote an entry on the `doc`.