### PR TITLE
fix for shell that don't to &&

### DIFF
--- a/R/tmux_split.vim
+++ b/R/tmux_split.vim
@@ -20,7 +20,8 @@ function StartR_TmuxSplit(rcmd)
                 \ 'set-environment NVIMR_COMPLDIR "' . substitute(g:rplugin_compldir, ' ', '\\ ', "g") . '"',
                 \ 'set-environment NVIMR_ID ' . $NVIMR_ID ,
                 \ 'set-environment NVIMR_SECRET ' . $NVIMR_SECRET ,
-                \ 'set-environment R_DEFAULT_PACKAGES ' . $R_DEFAULT_PACKAGES ]
+                \ 'set-environment R_DEFAULT_PACKAGES ' . $R_DEFAULT_PACKAGES ,
+				\ 'set-environment SHELL /bin/sh']
     if $NVIM_IP_ADDRESS != ""
         call extend(tmuxconf, ['set-environment NVIM_IP_ADDRESS ' . $NVIM_IP_ADDRESS ])
     endif

--- a/R/tmux_split.vim
+++ b/R/tmux_split.vim
@@ -20,8 +20,7 @@ function StartR_TmuxSplit(rcmd)
                 \ 'set-environment NVIMR_COMPLDIR "' . substitute(g:rplugin_compldir, ' ', '\\ ', "g") . '"',
                 \ 'set-environment NVIMR_ID ' . $NVIMR_ID ,
                 \ 'set-environment NVIMR_SECRET ' . $NVIMR_SECRET ,
-                \ 'set-environment R_DEFAULT_PACKAGES ' . $R_DEFAULT_PACKAGES ,
-				\ 'set-environment SHELL /bin/sh']
+                \ 'set-environment R_DEFAULT_PACKAGES ' . $R_DEFAULT_PACKAGES ]
     if $NVIM_IP_ADDRESS != ""
         call extend(tmuxconf, ['set-environment NVIM_IP_ADDRESS ' . $NVIM_IP_ADDRESS ])
     endif
@@ -84,7 +83,8 @@ function SendCmdToR_TmuxSplit(...)
     else
         let scmd = "tmux set-buffer '" . str . "\<C-M>' && tmux paste-buffer -t " . g:rplugin_rconsole_pane
     endif
-    let rlog = system(scmd)
+    let shscmd = "sh -c \"" . scmd . "\""
+    let rlog = system(shscmd)
     if v:shell_error
         let rlog = substitute(rlog, "\n", " ", "g")
         let rlog = substitute(rlog, "\r", " ", "g")

--- a/R/tmux_split.vim
+++ b/R/tmux_split.vim
@@ -83,7 +83,12 @@ function SendCmdToR_TmuxSplit(...)
     else
         let scmd = "tmux set-buffer '" . str . "\<C-M>' && tmux paste-buffer -t " . g:rplugin_rconsole_pane
     endif
-    let shscmd = "sh -c \"" . scmd . "\""
+	if g:R_wrap_sh
+	  let shscmd = "sh -c \"" . scmd . "\""
+	else
+	  let shscmd = scmd
+	endif
+
     let rlog = system(shscmd)
     if v:shell_error
         let rlog = substitute(rlog, "\n", " ", "g")


### PR DESCRIPTION
When fish is used as default shell the command `SendCmdToR_TmuxSplit` fails due to the `&&`.
I added the option `R_wrap_sh` to use `sh -c` to execute the command.