### PR TITLE
Use absolute path as returned by rmarkdown::render to open pdf

### DIFF
--- a/R/nvimcom/R/nvim.interlace.R
+++ b/R/nvimcom/R/nvim.interlace.R
@@ -304,6 +304,6 @@ nvim.interlace.rmd <- function(Rmdfile, outform = NULL, rmddir, view = TRUE, ...
                 browseURL(res)
             else
                 if(regexpr("\\.pdf", res) > 0)
-                    OpenPDF(sub(".*/", "", res))
+                    OpenPDF(res)
     }
 }


### PR DESCRIPTION
I ran into trouble where the PDF file could not be found after `rmarkdown::render()` because a chunk has changed the working directory. I think it should be generally safe to use the absolute path as returned by `render()` to find the PDF file (correct me if I'm wrong), so I removed the regex that removed the path.