### PR TITLE
Bugfix: Explicitly use `utils::help` in `gbRd.fun`

### DIFF
--- a/R/nvimcom/R/specialfuns.R
+++ b/R/nvimcom/R/specialfuns.R
@@ -28,7 +28,7 @@ gbRd.set_sectag <- function(s,sectag,eltag){
 
 gbRd.fun <- function(x){
     rdo <- NULL # prepare the "Rd" object rdo
-    x <- do.call("help", list(x, help_type = "text",
+    x <- do.call(utils::help, list(x, help_type = "text",
                                verbose = FALSE,
                                try.all.packages = FALSE))
     if(length(x) == 0)


### PR DESCRIPTION
This prevents it from being silently overwritten by `devtools::load_all`, which loads `devtools::help` which has behavior that breaks `gbRd.fun`, the code for accessing help files.

See #288.