### PR TITLE
Escape from infinite completion loop

### DIFF
--- a/R/common_global.vim
+++ b/R/common_global.vim
@@ -3142,10 +3142,17 @@ function GetRArgs1(base, rkeyword0, firstobj, pkg)
     call AddForDeletion(g:rplugin_tmpdir . "/args_for_completion")
     call SendToNvimcom("\x08" . $NVIMR_ID . msg)
 
-    let ii = 1000
+    let ii = 200
     while ii > 0 && s:ArgCompletionFinished == 0
+        echomsg "Attempting to parse completion. Countdown: " . ii
+        let ii = ii - 1
         sleep 30m
     endwhile
+
+    if s:ArgCompletionFinished == 0 && ii == 0
+        echomsg "Completion failed."
+        return []
+    endif
 
     let args_line = readfile(g:rplugin_tmpdir . "/args_for_completion")[0]
     call delete(g:rplugin_tmpdir . "/args_for_completion")

--- a/R/nvimcom/R/specialfuns.R
+++ b/R/nvimcom/R/specialfuns.R
@@ -28,7 +28,7 @@ gbRd.set_sectag <- function(s,sectag,eltag){
 
 gbRd.fun <- function(x){
     rdo <- NULL # prepare the "Rd" object rdo
-    x <- do.call("help", list(x, help_type = "text",
+    x <- do.call(utils::help, list(x, help_type = "text",
                                verbose = FALSE,
                                try.all.packages = FALSE))
     if(length(x) == 0)


### PR DESCRIPTION
Before, if anything went wrong with completion, this `while` loop would go on forever, effectively crashing vim. This forces the loop to end after some time, so the completion fails but the whole vim process doesn't die.

See #288 for discussion.

This PR is a superset of #292. I'm submitting it separately because it might be a more controversial fix than #288, and may warrant further discussion and/or a more elegant solution.