### PR TITLE
Fall back to installed docs (fixes #314)

### DIFF
--- a/R/nvimcom/R/nvim.help.R
+++ b/R/nvimcom/R/nvim.help.R
@@ -46,10 +46,10 @@ nvim.help <- function(topic, w, firstobj, package)
             try(hasfun <- is.function(pkgload::dev_help), silent = TRUE)
             if(hasfun){
                 tryCatch(pkgload::dev_help(topic),
-                         error = function(e) .C("nvimcom_msg_to_nvim",
-                                                "RWarningMsg('Unable to get dev documentation.')",
+                         error = function(e) e,
+                         finally = function(e) .C("nvimcom_msg_to_nvim",
+                                                "RWarningMsg('Unable to get dev documentation. Attempting to get installed documentation')",
                                                 PACKAGE = "nvimcom"))
-                return(invisible(NULL))
             }
         } else {
             if (package %in% devtools::dev_packages()) {


### PR DESCRIPTION
If pkgload::dev_help can't find dev docs, fall back to utils::help.

This should fix #314, which occurs when help is called on a function of an attached package that wasn't loaded by devtools or pkgload.  For example, any base function.