### PR TITLE
Fix help for devtools / pkgload

### DIFF
--- a/R/nvimcom/R/nvim.help.R
+++ b/R/nvimcom/R/nvim.help.R
@@ -39,27 +39,33 @@ nvim.help <- function(topic, w, firstobj, package)
     on.exit(options(pager = oldpager), add = TRUE)
     options(pager = nvim.hmsg)
 
-    # try devtools first (if loaded)
-    if ("devtools" %in% loadedNamespaces()) {
-        if (missing(package)) {
-            hasfun <- FALSE
-            try(hasfun <- is.function(pkgload::dev_help), silent = TRUE)
-            if(hasfun){
-                tryCatch(pkgload::dev_help(topic),
-                         error = function(e) e,
-                         finally = function(e) .C("nvimcom_msg_to_nvim",
-                                                "RWarningMsg('Unable to get dev documentation. Attempting to get installed documentation')",
-                                                PACKAGE = "nvimcom"))
-            }
-        } else {
-            if (package %in% devtools::dev_packages()) {
-                ret <- try(devtools::dev_help(topic), silent = TRUE)
-                if (inherits(ret, "try-error"))
-                    .C("nvimcom_msg_to_nvim",
-                       paste0("RWarningMsg('", as.character(ret), "')"),
-                       PACKAGE = "nvimcom")
-                return(invisible(NULL))
-            }
+    warn <- function(msg)
+    {
+        .C("nvimcom_msg_to_nvim",
+           paste0("RWarningMsg('", as.character(msg), "')"),
+           PACKAGE = "nvimcom")
+    }
+
+    if("devtools" %in% loadedNamespaces()) {
+        ret <- suppressMessages(try(devtools::dev_help(topic), silent = TRUE))
+
+        if (!inherits(ret, "try-error")) {
+            return(invisible(NULL))
+        }
+        if (!missing(package) && package %in% devtools::dev_packages()) {
+            warn(ret)
+            return(invisible(NULL))
+        }
+    } else if("pkgload" %in% loadedNamespaces()) {
+        ret <- try(pkgload::dev_help(topic), silent = TRUE)
+
+        if(!inherits(ret, "try-error")) {
+            suppressMessages(print(ret))
+            return(invisible(NULL))
+        }
+        if (!missing(package) && pkgload::is_dev_package(package)) {
+            warn(ret)
+            return(invisible(NULL))
         }
     }
 

--- a/R/nvimcom/R/nvim.help.R
+++ b/R/nvimcom/R/nvim.help.R
@@ -51,19 +51,19 @@ nvim.help <- function(topic, w, firstobj, package)
 
         if (!inherits(ret, "try-error")) {
             return(invisible(NULL))
-        }
-        if (!missing(package) && package %in% devtools::dev_packages()) {
+        } else if(!missing(package) && package %in% devtools::dev_packages()) {
             warn(ret)
             return(invisible(NULL))
         }
-    } else if("pkgload" %in% loadedNamespaces()) {
+    } 
+
+    if("pkgload" %in% loadedNamespaces()) {
         ret <- try(pkgload::dev_help(topic), silent = TRUE)
 
         if(!inherits(ret, "try-error")) {
             suppressMessages(print(ret))
             return(invisible(NULL))
-        }
-        if (!missing(package) && pkgload::is_dev_package(package)) {
+        } else if(!missing(package) && pkgload::is_dev_package(package)) {
             warn(ret)
             return(invisible(NULL))
         }


### PR DESCRIPTION
The help is broken on my system, and #317 did not fix it. AFAICT the logic in https://github.com/jalvesaq/Nvim-R/blob/master/R/nvimcom/R/nvim.help.R#L42-L64 is flawed. E.g., if `devtools` is not loaded (https://github.com/jalvesaq/Nvim-R/blob/master/R/nvimcom/R/nvim.help.R#L54), nevertheless call a function of devtools in https://github.com/jalvesaq/Nvim-R/blob/master/R/nvimcom/R/nvim.help.R#L55.

I re-wrote and tested this block with both `devtools` and `pkgload`, and it seems to work on my box.