### PR TITLE
Query Tmux for pane-base-index

### DIFF
--- a/R/extern_term.vim
+++ b/R/extern_term.vim
@@ -99,9 +99,9 @@ function SendCmdToR_Term(...)
         let str = ' ' . str
     endif
     if a:0 == 2 && a:2 == 0
-        let scmd = "tmux -L NvimR set-buffer '" . str . "' && tmux -L NvimR paste-buffer -t " . g:rplugin_tmuxsname . '.0'
+        let scmd = "tmux -L NvimR set-buffer '" . str . "' && tmux -L NvimR paste-buffer -t " . g:rplugin_tmuxsname . '.' . TmuxOption("pane-base-index", "window")
     else
-        let scmd = "tmux -L NvimR set-buffer '" . str . "\<C-M>' && tmux -L NvimR paste-buffer -t " . g:rplugin_tmuxsname . '.0'
+        let scmd = "tmux -L NvimR set-buffer '" . str . "\<C-M>' && tmux -L NvimR paste-buffer -t " . g:rplugin_tmuxsname . '.' . TmuxOption("pane-base-index", "window")
     endif
     let rlog = system(scmd)
     if v:shell_error

--- a/R/tmux.vim
+++ b/R/tmux.vim
@@ -26,6 +26,16 @@ else
 endif
 unlet s:tmuxversion
 
+" Define a function to retrieve tmux settings
+function TmuxOption(option, isglobal)
+	if a:isglobal == "global"
+		let result = system("tmux show-options -gv ". a:option)
+	else
+		let result = system("tmux show-window-options -gv ". a:option)
+	endif
+	return substitute(result, '\n\+$', '', '')
+endfunction
+
 let g:rplugin_tmuxsname = "NvimR-" . substitute(localtime(), '.*\(...\)', '\1', '')
 
 let g:R_setwidth = get(g:, 'R_setwidth', 2)


### PR DESCRIPTION
Some users load their custom tmux.conf with the R_notmuxconf = 1 option
and define the "pane-base-index" to start at something other than 0.
Since SendCmdToR_Term only looks for pane 0, this causes the function to
fail. When calling the SendCmdToR_Term() function, query the pane-base-index
from tmux directly and use the value.