### PR TITLE
Add `local = parent.frame()` in NvimR.* functions

### DIFF
--- a/R/nvimcom/R/nvimcom.R
+++ b/R/nvimcom/R/nvimcom.R
@@ -177,15 +177,15 @@ NvimR.source <- function(..., print.eval = TRUE, spaced = FALSE)
     base::source(getOption("nvimcom.source.path"), ..., print.eval = print.eval, spaced = spaced)
 }
 
-NvimR.selection <- function(...) NvimR.source(...)
+NvimR.selection <- function(..., local = parent.frame()) NvimR.source(..., local = local)
 
-NvimR.paragraph <- function(...) NvimR.source(...)
+NvimR.paragraph <- function(..., local = parent.frame()) NvimR.source(..., local = local)
 
-NvimR.block <- function(...) NvimR.source(...)
+NvimR.block <- function(..., local = parent.frame()) NvimR.source(..., local = local)
 
-NvimR.function <- function(...) NvimR.source(...)
+NvimR.function <- function(..., local = parent.frame()) NvimR.source(..., local = local)
 
-NvimR.chunk <- function(...) NvimR.source(...)
+NvimR.chunk <- function(..., local = parent.frame()) NvimR.source(..., local = local)
 
 source.and.clean <- function(f, ...)
 {


### PR DESCRIPTION
See https://github.com/jalvesaq/Nvim-R/issues/384

Most source functions in NVim-R call `NvimR.source()` behind the scene. Add a default `local = parent.frame()` in `NvimR.*()` will make sure the source functions work as expected in debug mode.