### PR TITLE
Fix tmux version when tmux -V reports things like `next-3.0`

### DIFF
--- a/R/tmux.vim
+++ b/R/tmux.vim
@@ -14,6 +14,7 @@ if system("uname") =~ "OpenBSD"
 else
     let s:tmuxversion = system("tmux -V")
     let s:tmuxversion = substitute(s:tmuxversion, "master", "1.8", "")
+    let s:tmuxversion = substitute(s:tmuxversion, "next", "1.8", "")
     let s:tmuxversion = substitute(s:tmuxversion, '.*tmux \([0-9]\.[0-9]\).*', '\1', '')
     if strlen(s:tmuxversion) != 3
         let s:tmuxversion = "1.0"


### PR DESCRIPTION
Closes #400. I've tried adding a regex (i.e `master\|next`) but cannot get it work so I do a new substitution. Feel free to modify it.