### PR TITLE
Activate the plugin on .Rproj files

### DIFF
--- a/ftdetect/r.vim
+++ b/ftdetect/r.vim
@@ -3,3 +3,4 @@ autocmd BufNewFile,BufRead *.Rout.save set ft=rout
 autocmd BufNewFile,BufRead *.Rout.fail set ft=rout
 autocmd BufNewFile,BufRead *.Rprofile set ft=r
 autocmd BufNewFile,BufRead *.Rproj set ft=r
+autocmd BufNewFile,BufRead *.Rproj set syntax=yaml

--- a/ftdetect/r.vim
+++ b/ftdetect/r.vim
@@ -2,4 +2,4 @@ autocmd BufNewFile,BufRead *.Rout set ft=rout
 autocmd BufNewFile,BufRead *.Rout.save set ft=rout
 autocmd BufNewFile,BufRead *.Rout.fail set ft=rout
 autocmd BufNewFile,BufRead *.Rprofile set ft=r
-autocmd BufNewFile,BufRead *.Rproj set ft=r
+autocmd BufNewFile,BufRead *.Rproj set ft=rout

--- a/ftdetect/r.vim
+++ b/ftdetect/r.vim
@@ -2,3 +2,4 @@ autocmd BufNewFile,BufRead *.Rout set ft=rout
 autocmd BufNewFile,BufRead *.Rout.save set ft=rout
 autocmd BufNewFile,BufRead *.Rout.fail set ft=rout
 autocmd BufNewFile,BufRead *.Rprofile set ft=r
+autocmd BufNewFile,BufRead *.Rproj set ft=r

--- a/ftdetect/r.vim
+++ b/ftdetect/r.vim
@@ -2,4 +2,4 @@ autocmd BufNewFile,BufRead *.Rout set ft=rout
 autocmd BufNewFile,BufRead *.Rout.save set ft=rout
 autocmd BufNewFile,BufRead *.Rout.fail set ft=rout
 autocmd BufNewFile,BufRead *.Rprofile set ft=r
-autocmd BufNewFile,BufRead *.Rproj set ft=rout
+autocmd BufNewFile,BufRead *.Rproj set ft=r


### PR DESCRIPTION
This solves #405, but I'm not sure that it's the optimal way to do that, because `.Rproj` can't be executed as R code...