### PR TITLE
Fix nvimcom for _R_CHECK_LENGTH_1_CONDITION_=true and _R_CHECK_LENGTH_1_LOGIC2_=true

### DIFF
--- a/R/nvimcom/R/nvim.bol.R
+++ b/R/nvimcom/R/nvim.bol.R
@@ -200,7 +200,7 @@ CleanOmniLineUTF8 <- function(x)
     x
 }
 
-if(!is.na(localeToCharset()) && localeToCharset()[1] == "UTF-8" && version$os != "cygwin"){
+if(!is.na(localeToCharset()[1]) && localeToCharset()[1] == "UTF-8" && version$os != "cygwin"){
     CleanOmniLine <- CleanOmniLineUTF8
 } else {
     CleanOmniLine <- CleanOmniLineASCII


### PR DESCRIPTION
This PR fixes a comparison where a logical vector of arbitrary length is used in a `if()`. Only pops up if the respective environment variables are set and if the locale has at least two elements, but under these circumstances the package does not build, exiting with the exception:
```
Error in !is.na(localeToCharset()) && localeToCharset()[1] == "UTF-8" : 
  'length(x) = 2 > 1' in coercion to 'logical(1)'
```

Note that these additional checks might become enabled by default in future R versions.