### PR TITLE
Send arbitrary lines and motion region to R

### DIFF
--- a/R/common_global.vim
+++ b/R/common_global.vim
@@ -1739,8 +1739,9 @@ function RParenDiff(str)
 endfunction
 
 " Send current line to R.
-function SendLineToR(godown)
-    let line = getline(".")
+function SendLineToR(godown, ...)
+    let lnum = get(a:, 1, ".")
+    let line = getline(lnum)
     if strlen(line) == 0
         if a:godown =~ "down"
             call GoDown()

--- a/R/common_global.vim
+++ b/R/common_global.vim
@@ -1388,6 +1388,18 @@ function RSourceLines(...)
     return ok
 endfunction
 
+" Send motion to R
+function SendMotionToR(type)
+    let lstart = line("'[")
+    let lend = line("']")
+    if lstart == lend
+        call SendLineToR("stay", lstart)
+    else
+        let lines = getline(lstart, lend)
+        call RSourceLines(lines, "", "lines")
+    endif
+endfunction
+
 " Send file to R
 function SendFileToR(e)
     let flines = getline(1, "$")
@@ -3007,6 +3019,7 @@ function RCreateSendMaps()
     call RCreateMaps('ni0', '<Plug>RDSendLineAndInsertOutput', 'o', ':call SendLineToRAndInsertOutput()')
     call RCreateMaps('v', '<Plug>RDSendLineAndInsertOutput', 'o', ':call RWarningMsg("This command does not work over a selection of lines.")')
     call RCreateMaps('i', '<Plug>RSendLAndOpenNewOne', 'q', ':call SendLineToR("newline")')
+    call RCreateMaps("ni", '<Plug>RSendMotion', 'm', ':set opfunc=SendMotionToR<CR>g@')
     call RCreateMaps('n', '<Plug>RNLeftPart', 'r<left>', ':call RSendPartOfLine("left", 0)')
     call RCreateMaps('n', '<Plug>RNRightPart', 'r<right>', ':call RSendPartOfLine("right", 0)')
     call RCreateMaps('i', '<Plug>RILeftPart', 'r<left>', 'l:call RSendPartOfLine("left", 1)')
@@ -3654,9 +3667,9 @@ endif
 
 " Make the file name of files to be sourced
 if exists("g:R_remote_tmpdir")
-	let s:Rsource_read = g:R_remote_tmpdir . "/Rsource-" . getpid()
+    let s:Rsource_read = g:R_remote_tmpdir . "/Rsource-" . getpid()
 else
-	let s:Rsource_read = g:rplugin.tmpdir . "/Rsource-" . getpid()
+    let s:Rsource_read = g:rplugin.tmpdir . "/Rsource-" . getpid()
 endif
 let s:Rsource_write = g:rplugin.tmpdir . "/Rsource-" . getpid()
 

--- a/R/common_global.vim
+++ b/R/common_global.vim
@@ -2892,7 +2892,7 @@ function RCreateMaps(type, plug, combo, target)
     if a:type =~ '0'
         let tg = a:target . '<CR>0'
         let il = 'i'
-    elseif a:type =~ 'N'
+    elseif a:type =~ '\.'
         let tg = a:target
         let il = 'a'
     else
@@ -3022,7 +3022,7 @@ function RCreateSendMaps()
     call RCreateMaps('ni0', '<Plug>RDSendLineAndInsertOutput', 'o', ':call SendLineToRAndInsertOutput()')
     call RCreateMaps('v', '<Plug>RDSendLineAndInsertOutput', 'o', ':call RWarningMsg("This command does not work over a selection of lines.")')
     call RCreateMaps('i', '<Plug>RSendLAndOpenNewOne', 'q', ':call SendLineToR("newline")')
-    call RCreateMaps("niN", '<Plug>RSendMotion', 'm', ':set opfunc=SendMotionToR<CR>g@')
+    call RCreateMaps("ni.", '<Plug>RSendMotion', 'm', ':set opfunc=SendMotionToR<CR>g@')
     call RCreateMaps('n', '<Plug>RNLeftPart', 'r<left>', ':call RSendPartOfLine("left", 0)')
     call RCreateMaps('n', '<Plug>RNRightPart', 'r<right>', ':call RSendPartOfLine("right", 0)')
     call RCreateMaps('i', '<Plug>RILeftPart', 'r<left>', 'l:call RSendPartOfLine("left", 1)')

--- a/R/common_global.vim
+++ b/R/common_global.vim
@@ -1396,7 +1396,7 @@ function SendMotionToR(type)
         call SendLineToR("stay", lstart)
     else
         let lines = getline(lstart, lend)
-        call RSourceLines(lines, "", "lines")
+        call RSourceLines(lines, "", "block")
     endif
 endfunction
 
@@ -2892,6 +2892,9 @@ function RCreateMaps(type, plug, combo, target)
     if a:type =~ '0'
         let tg = a:target . '<CR>0'
         let il = 'i'
+    elseif a:type =~ 'N'
+        let tg = a:target
+        let il = 'a'
     else
         let tg = a:target . '<CR>'
         let il = 'a'
@@ -3019,7 +3022,7 @@ function RCreateSendMaps()
     call RCreateMaps('ni0', '<Plug>RDSendLineAndInsertOutput', 'o', ':call SendLineToRAndInsertOutput()')
     call RCreateMaps('v', '<Plug>RDSendLineAndInsertOutput', 'o', ':call RWarningMsg("This command does not work over a selection of lines.")')
     call RCreateMaps('i', '<Plug>RSendLAndOpenNewOne', 'q', ':call SendLineToR("newline")')
-    call RCreateMaps("ni", '<Plug>RSendMotion', 'm', ':set opfunc=SendMotionToR<CR>g@')
+    call RCreateMaps("niN", '<Plug>RSendMotion', 'm', ':set opfunc=SendMotionToR<CR>g@')
     call RCreateMaps('n', '<Plug>RNLeftPart', 'r<left>', ':call RSendPartOfLine("left", 0)')
     call RCreateMaps('n', '<Plug>RNRightPart', 'r<right>', ':call RSendPartOfLine("right", 0)')
     call RCreateMaps('i', '<Plug>RILeftPart', 'r<left>', 'l:call RSendPartOfLine("left", 1)')


### PR DESCRIPTION
sometimes it is handy to use the motions known in vim to select a region that should be sent to R. This is now possible with the `\m` command, e.g. `\m}` (end of paragraph) or `\m3j` (the next 3 lines including current line).