### PR TITLE
fixed a very small error that caused me a huge headache

### DIFF
--- a/R/bibcompl.vim
+++ b/R/bibcompl.vim
@@ -100,7 +100,7 @@ function GetBibAttachment()
                 let fpath = g:rplugin.last_attach
                 let fls = split(fpath, ':')
                 if filereadable(fls[0])
-                    let fpath = [0]
+                    let fpath = fls[0]
                 elseif len(fls) > 1 && filereadable(fls[1])
                     let fpath = fls[1]
                 endif


### PR DESCRIPTION
I was having trouble getting \od to open the files listed in my .bib, so
I dug into the source code and find the error. There was a [0] where
there should have been a fls[0].

As always, thanks for the amazing plugin. I hope I've done my very small
part to contribute.