### PR TITLE
Support rendering Rmarkdown to all formats in YAML

### DIFF
--- a/R/common_global.vim
+++ b/R/common_global.vim
@@ -801,6 +801,7 @@ function RControlMaps()
     " Render script with rmarkdown
     "-------------------------------------
     call RCreateMaps('nvi', 'RMakeRmd',    'kr', ':call RMakeRmd("default")')
+    call RCreateMaps('nvi', 'RMakeAll',    'ka', ':call RMakeRmd("all")')
     call RCreateMaps('nvi', 'RMakePDFK',   'kp', ':call RMakeRmd("pdf_document")')
     call RCreateMaps('nvi', 'RMakePDFKb',  'kl', ':call RMakeRmd("beamer_presentation")')
     call RCreateMaps('nvi', 'RMakeWord',   'kw', ':call RMakeRmd("word_document")')

--- a/R/gui_running.vim
+++ b/R/gui_running.vim
@@ -251,6 +251,7 @@ function MakeRMenu()
         call RCreateMenuItem('nvi', 'Command.Knit\ and\ ODT\ (cur\ file)', 'RMakeODT', 'ko', ':call RMakeRmd("odt_document")')
         call RCreateMenuItem('nvi', 'Command.Knit\ and\ Word\ Document\ (cur\ file)', 'RMakeWord', 'kw', ':call RMakeRmd("word_document")')
         call RCreateMenuItem('nvi', 'Command.Markdown\ render\ (cur\ file)', 'RMakeRmd', 'kr', ':call RMakeRmd("default")')
+        call RCreateMenuItem('nvi', 'Command.Markdown\ render\ [all\ in\ YAML]\ (cur\ file)', 'RMakeRmd', 'ka', ':call RMakeRmd("all")')
     endif
     if &filetype == "r" || g:R_never_unmake_menu
         call RCreateMenuItem('nvi', 'Command.Spin\ (cur\ file)', 'RSpin', 'ks', ':call RSpin()')

--- a/doc/Nvim-R.txt
+++ b/doc/Nvim-R.txt
@@ -393,6 +393,7 @@ Command
   . Knit and ODT (cur file)                            \ko
   . Knit and Word Document (cur file)                  \kw
   . Markdown render (cur file)                         \kr
+  . Markdown render [all in YAML] (cur file)           \ka
   . Spin (cur file) (only .R)                          \ks
   --------------------------------------------------------
   . Open attachment of reference (Rmd, Rnoweb)         \oa
@@ -2529,7 +2530,7 @@ the list of the names for custom key bindings (the prefix RE means "echo"; RD,
    RMakeODT	(.Rmd, Open document)
    RMakeWord	(.Rmd, Word document)
    RMakeRmd	(rmarkdown default)
-   RMakeAll	(rmarkdown all in yaml)
+   RMakeAll	(rmarkdown all in YAML)
    ROpenPDF
    RSyncFor	(SyncTeX search forward)
    RGoToTeX	(Got to LaTeX output)


### PR DESCRIPTION
The existing `RMakeRmd` command (binding: `\kr`) renders the current Rmarkdown file to the "default" (*i.e.* the first one specified in the YAML header) output format.
This adds a new `RMakeAll` command (and binds it to `\ka`) that enables rendering to all output formats specified in the YAML header at once.