### PR TITLE
Fix sending R code to terminal in newer nvim

### DIFF
--- a/R/extern_term.vim
+++ b/R/extern_term.vim
@@ -121,7 +121,7 @@ function SendCmdToR_Term(...)
     if a:0 == 2 && a:2 == 0
         let scmd = "tmux -L NvimR set-buffer '" . str . "' && tmux -L NvimR paste-buffer -t " . g:rplugin.tmuxsname . '.' . TmuxOption("pane-base-index", "window")
     else
-        let scmd = "tmux -L NvimR set-buffer '" . str . "\<C-M>' && tmux -L NvimR paste-buffer -t " . g:rplugin.tmuxsname . '.' . TmuxOption("pane-base-index", "window")
+        let scmd = "tmux -L NvimR set-buffer '" . str . "\<CR>' && tmux -L NvimR paste-buffer -t " . g:rplugin.tmuxsname . '.' . TmuxOption("pane-base-index", "window")
     endif
     let rlog = system(scmd)
     if v:shell_error

--- a/R/tmux_split.vim
+++ b/R/tmux_split.vim
@@ -101,7 +101,7 @@ function SendCmdToR_TmuxSplit(...)
     if a:0 == 2 && a:2 == 0
         let scmd = "tmux set-buffer '" . str . "' && tmux paste-buffer -t " . g:rplugin.rconsole_pane
     else
-        let scmd = "tmux set-buffer '" . str . "\<C-M>' && tmux paste-buffer -t " . g:rplugin.rconsole_pane
+        let scmd = "tmux set-buffer '" . str . "\<CR>' && tmux paste-buffer -t " . g:rplugin.rconsole_pane
     endif
     let rlog = system(scmd)
     if v:shell_error


### PR DESCRIPTION
Neovim recently changed how "ctrl input pairs" like `<C-M>` etc. work (see https://github.com/neovim/neovim/pull/17825), and (as far as I understand) they are no longer equivalent to `<CR>` etc. This seems to have broken sending code from nvim to an external terminal. Replacing both instances of `<C-M>` with `<CR>` in the command line sent to the terminal (via tmux) appears to fix it, but I haven't tested this on older nvim or vim versions or with tmux splits.