### PR TITLE
Fix encoding issue for start options file on Windows

### DIFF
--- a/R/nvimcom/R/nvimcom.R
+++ b/R/nvimcom/R/nvimcom.R
@@ -12,7 +12,9 @@ NvimcomEnv$pkgdescr <- list()
 
     # The remaining options are set by Neovim. Don't try to set them in your
     # ~/.Rprofile because they will be overridden here:
-    if(file.exists(paste0(Sys.getenv("NVIMR_TMPDIR"), "/start_options.R"))){
+    if(file.exists(paste0(Sys.getenv("NVIMR_TMPDIR"), "/start_options_utf8.R"))){
+        source(paste0(Sys.getenv("NVIMR_TMPDIR"), "/start_options_utf8.R"), encoding = "UTF-8")
+    } else if(file.exists(paste0(Sys.getenv("NVIMR_TMPDIR"), "/start_options.R"))){
         source(paste0(Sys.getenv("NVIMR_TMPDIR"), "/start_options.R"))
     } else {
         options(nvimcom.allnames = FALSE)

--- a/R/start_r.vim
+++ b/R/start_r.vim
@@ -140,14 +140,7 @@ function StartR(whatr)
         " `rwd` will not be a real directory if editing a file on the internet
         " with netrw plugin
         if isdirectory(rwd)
-            if has("win32") && &encoding == "utf-8"
-                let start_options += ['.nvim.rwd <- "' . rwd . '"']
-                let start_options += ['Encoding(.nvim.rwd) <- "UTF-8"']
-                let start_options += ['setwd(.nvim.rwd)']
-                let start_options += ['rm(.nvim.rwd)']
-            else
-                let start_options += ['setwd("' . rwd . '")']
-            endif
+            let start_options += ['setwd("' . rwd . '")']
         endif
     endif
 

--- a/R/start_r.vim
+++ b/R/start_r.vim
@@ -76,11 +76,10 @@ function StartR(whatr)
     call AddForDeletion(g:rplugin.tmpdir . "/nvimbol_finished")
 
     if &encoding == "utf-8"
-        s:fn_start_options = "start_options_utf8.R"
+        call AddForDeletion(g:rplugin.tmpdir . "/start_options_utf8.R")
     else
-        s:fn_start_options = "start_options.R"
+        call AddForDeletion(g:rplugin.tmpdir . "/start_options.R")
     endif
-    call AddForDeletion(g:rplugin.tmpdir . "/" . s:fn_start_options)
 
     call AddForDeletion(g:rplugin.tmpdir . "/args_for_completion")
 
@@ -152,7 +151,11 @@ function StartR(whatr)
         endif
     endif
 
-    call writefile(start_options, g:rplugin.tmpdir . "/" . s:fn_start_options)
+    if &encoding == "utf-8"
+        call writefile(start_options, g:rplugin.tmpdir . "/start_options_utf8.R")
+    else
+        call writefile(start_options, g:rplugin.tmpdir . "/start_options.R")
+    endif
 
     " Required to make R load nvimcom without the need of the user including
     " library(nvimcom) in his or her ~/.Rprofile.

--- a/R/start_r.vim
+++ b/R/start_r.vim
@@ -74,7 +74,14 @@ function StartR(whatr)
     call AddForDeletion(g:rplugin.tmpdir . "/globenv_" . $NVIMR_ID)
     call AddForDeletion(g:rplugin.tmpdir . "/liblist_" . $NVIMR_ID)
     call AddForDeletion(g:rplugin.tmpdir . "/nvimbol_finished")
-    call AddForDeletion(g:rplugin.tmpdir . "/start_options.R")
+
+    if &encoding == "utf-8"
+        s:fn_start_options = "start_options_utf8.R"
+    else
+        s:fn_start_options = "start_options.R"
+    endif
+    call AddForDeletion(g:rplugin.tmpdir . "/" . fn_start_options)
+
     call AddForDeletion(g:rplugin.tmpdir . "/args_for_completion")
 
     " Reset R_DEFAULT_PACKAGES to its original value (see https://github.com/jalvesaq/Nvim-R/issues/554):
@@ -145,7 +152,7 @@ function StartR(whatr)
         endif
     endif
 
-    call writefile(start_options, g:rplugin.tmpdir . "/start_options.R")
+    call writefile(start_options, g:rplugin.tmpdir . "/" . fn_start_options)
 
     " Required to make R load nvimcom without the need of the user including
     " library(nvimcom) in his or her ~/.Rprofile.

--- a/R/start_r.vim
+++ b/R/start_r.vim
@@ -80,7 +80,7 @@ function StartR(whatr)
     else
         s:fn_start_options = "start_options.R"
     endif
-    call AddForDeletion(g:rplugin.tmpdir . "/" . fn_start_options)
+    call AddForDeletion(g:rplugin.tmpdir . "/" . s:fn_start_options)
 
     call AddForDeletion(g:rplugin.tmpdir . "/args_for_completion")
 
@@ -152,7 +152,7 @@ function StartR(whatr)
         endif
     endif
 
-    call writefile(start_options, g:rplugin.tmpdir . "/" . fn_start_options)
+    call writefile(start_options, g:rplugin.tmpdir . "/" . s:fn_start_options)
 
     " Required to make R load nvimcom without the need of the user including
     " library(nvimcom) in his or her ~/.Rprofile.


### PR DESCRIPTION
### Pull Request Review

- Fixes #662

The default encoding for R on Windows is `"native.enc"` (Hopefully this will [change for R 4.2](https://developer.r-project.org/Blog/public/2021/12/07/upcoming-changes-in-r-4.2-on-windows/)). This causes an error from Nvim-R when sourcing the `start_options.R` file encoded with UTF-8 from a working directory that contains multibyte characters.

This PR adds a simple logic to fix this issue:
1. If current Vim encoding is `utf-8`, which means `writefile()` will also save files with `utf-8` encoding, write the start options in a file named `start_options_utf8.R`.
2. Otherwise, write the start options in a file named `start_options.R`, i.e. the original one.
3. When loading nvimcom, detect `start_options_utf8.R`. If it exists, source it with `encoding = "UTF-8"` option. Otherwise, fallback to the original logic.