### PR TITLE
Ensure only linebreak is used to split

### DIFF
--- a/R/start_ncs.vim
+++ b/R/start_ncs.vim
@@ -454,10 +454,10 @@ if exists("*WaitVimComStart")
     echohl None
 endif
 
-let s:ff = split(globpath(&rtp, "R/functions.vim"))
+let s:ff = split(globpath(&rtp, "R/functions.vim"), '\n')
 if len(s:ff) > 1
     function WarnDupNvimR()
-        let ff = split(globpath(&rtp, "R/functions.vim"))
+        let ff = split(globpath(&rtp, "R/functions.vim"), '\n')
         let msg = ["", "===   W A R N I N G   ===", "",
                     \ "It seems that Nvim-R is installed in more than one place.",
                     \ "Please, remove one of them to avoid conflicts.",


### PR DESCRIPTION
On widows in the search for multiple copies of nvim-r spaces in the filename like the common `C:\Documents and Settings\...` etc., are getting split into two paths, triggering the warning that there are multiple nvim-r installs. This fixes that issue by explicitly only splitting paths on linebreaks.