### PR TITLE
Add new R_debug_center option to center the QuickFixLine

### DIFF
--- a/R/start_r.vim
+++ b/R/start_r.vim
@@ -752,6 +752,10 @@ function FindDebugFunc(srcref)
 endfunction
 
 function RDebugJump(fnm, lnum)
+    let saved_so = &scrolloff
+    if g:R_debug_center == 1
+        set so=999
+    endif
     if a:fnm == '' || a:fnm == '<text>'
         " Functions sent directly to R Console have no associated source file
         " and functions sourced by knitr have '<text>' as source reference.
@@ -810,6 +814,7 @@ function RDebugJump(fnm, lnum)
         exe 'sb ' . bname
     endif
     let s:rdebugging = 1
+    exe 'set so=' . saved_so
 endfunction
 
 
@@ -2102,6 +2107,7 @@ let g:R_esc_term          = get(g:, "R_esc_term",           1)
 let g:R_close_term        = get(g:, "R_close_term",         1)
 let g:R_buffer_opts       = get(g:, "R_buffer_opts", "winfixwidth winfixheight nobuflisted")
 let g:R_debug             = get(g:, "R_debug",              1)
+let g:R_debug_center      = get(g:, "R_debug_center",       0)
 let g:R_dbg_jump          = get(g:, "R_dbg_jump",           1)
 let g:R_wait              = get(g:, "R_wait",              60)
 let g:R_wait_reply        = get(g:, "R_wait_reply",         2)

--- a/doc/Nvim-R.txt
+++ b/doc/Nvim-R.txt
@@ -886,6 +886,14 @@ defined by your colorscheme, but you can change them in your |vimrc| (see
    hi QuickFixLine ctermfg=231 ctermbg=23 guifg=white guibg=#005f5f
 <
 
+The QuickFixLine incrementally moves down the buffer with code execution and
+with long scripts it may stay at the bottom of the buffer as you debug. You
+can hold the highlighted line in the middle of the buffer with
+
+>
+    let R_debug_center = 1
+<
+
 ==============================================================================
 							   *Nvim-R-known-bugs*
 5. Known bugs and workarounds~
@@ -3213,7 +3221,8 @@ Examples:
 10. News~
 
  * New options: R_set_omnifunc, R_auto_omni, R_rmarkdown_args,
-   R_objbr_auto_start, R_quarto_render_args, and R_quarto_preview_args.
+   R_objbr_auto_start, R_quarto_render_args, and R_quarto_preview_args,
+   R_debug_center.
  * Delete options: R_omni_tmp_file and R_omni_size
 
 0.9.16 (2021-04-29)


### PR DESCRIPTION
With R_debug_center set to 1, the QuickFixLine will stay in the center
of the buffer while debugging. This provides more code context around
the line being debugged.

Let me know if the News needs changing, since I'm not sure when the versioning is incremented.
Thanks!