### PR TITLE
Edit non-existing function name

### DIFF
--- a/ftplugin/quarto_nvimr.vim
+++ b/ftplugin/quarto_nvimr.vim
@@ -14,7 +14,7 @@ function! RQuarto(what)
         update
         call g:SendCmdToR('quarto::quarto_preview("' . expand('%') . '"' . g:R_quarto_preview_args . ')')
     else
-        call g:SendCmdToR('quarto::quarto_stop()')
+        call g:SendCmdToR('quarto::quarto_preview_stop()')
     endif
 endfunction
 


### PR DESCRIPTION
Hi,

I noticed that the shortcut `\qs` which is used to stop the preview of a quarto document did not work. It seems that the `R` function `quarto::quarto_stop()` does not exist (anymore?). However, there is a function `quarto::quarto_preview_stop()` that stops the running preview. This PR just replaces the former by the latter.

Thanks for your work on this great plugin.

