### PR TITLE
Improve performance of nvimcom launch

### DIFF
--- a/R/before_nrs.R
+++ b/R/before_nrs.R
@@ -59,7 +59,7 @@ cat(libp, sep = "\n", colapse = "\n", file = "libPaths")
 # Check R version
 R_version <- paste0(version[c("major", "minor")], collapse = ".")
 
-if (R_version < "4.0.0")
+if (package_version(R_version) < "4.0.0")
     out("RWarn: Nvim-R requires R >= 4.0.0")
 
 R_version <- sub("[0-9]$", "", R_version)

--- a/R/nvimcom/NAMESPACE
+++ b/R/nvimcom/NAMESPACE
@@ -8,5 +8,5 @@ importFrom("methods", "existsFunction", "slotNames")
 importFrom("graphics", "boxplot", "hist", "par", "plot")
 importFrom("stats", "runif")
 importFrom("utils", "browseURL", "capture.output", "example", "find",
-           "getAnywhere", "installed.packages", "methods",
+           "getAnywhere", "methods",
            "packageDescription", "read.table", "str", "Sweave", "write.table")

--- a/R/nvimcom/R/nvimcom.R
+++ b/R/nvimcom/R/nvimcom.R
@@ -39,21 +39,20 @@ NvimcomEnv$pkgdescr <- list()
 
     if (interactive() && termenv != "" && termenv != "dumb" && Sys.getenv("NVIMR_COMPLDIR") != "") {
         dir.create(Sys.getenv("NVIMR_COMPLDIR"), showWarnings = FALSE)
-        ip <- utils::installed.packages()
-        nvinf <- ip["nvimcom", c("Version", "LibPath", "Built")]
+        nvinf <- packageDescription("nvimcom")
         .C("nvimcom_Start",
            as.integer(getOption("nvimcom.verbose")),
            as.integer(getOption("nvimcom.allnames")),
            as.integer(getOption("nvimcom.setwidth")),
            as.integer(getOption("nvimcom.autoglbenv")),
            as.integer(getOption("nvimcom.debug_r")),
-           nvinf[1],
-           nvinf[2],
-           paste(nvinf[3],
+           nvinf$Version,
+           nvinf$LibPath,
+           paste(sub("R ([^;]*).*", "\\1", nvinf$Built),
                  getOption("OutDec"),
                  gsub("\n", "#N#", getOption("prompt")),
                  getOption("continue"),
-                 as.integer(length(grep("colorout", rownames(ip))) == 1),
+                 length(find.package("colorout", quiet = TRUE)),
                  sep = "\x02"),
            PACKAGE = "nvimcom")
     }

--- a/R/nvimcom/R/specialfuns.R
+++ b/R/nvimcom/R/specialfuns.R
@@ -130,17 +130,15 @@ source.and.clean <- function(f, ...) {
 
 nvim_format <- function(l1, l2, wco, sw, txt) {
     if (is.null(getOption("nvimcom.formatfun"))) {
-        if ("styler" %in% rownames(installed.packages())) {
-           options(nvimcom.formatfun = "style_text")
+        if (length(find.package("styler", quiet = TRUE)) == 1) {
+            options(nvimcom.formatfun = "style_text")
+        } else if (length(find.package("formatR", quiet = TRUE)) == 1) {
+            options(nvimcom.formatfun = "tidy_source")
         } else {
-            if ("formatR" %in% rownames(installed.packages())) {
-                options(nvimcom.formatfun = "tidy_source")
-            } else {
-                .C("nvimcom_msg_to_nvim",
-                   "call RWarningMsg('You have to install either formatR or styler in order to run :Rformat')",
-                   PACKAGE = "nvimcom")
-                return(invisible(NULL))
-            }
+            .C("nvimcom_msg_to_nvim",
+               "call RWarningMsg('You have to install either formatR or styler in order to run :Rformat')",
+               PACKAGE = "nvimcom")
+            return(invisible(NULL))
         }
     }
 


### PR DESCRIPTION
Currently, Nvim-R and ‘nvimcom’ repeatedly query `installed.packages()` to find information about installed packages. Unfortunately, `installed.packages()` can be *very* slow — up to several seconds! — for large package libraries and/or slow secondary storage (e.g. via network). Having multiple calls in separate processes exacerbates this.

This PR replaces all occurrences of `installed.packages()` …

* with `find.package()` to check for package existence, and
* with `packageDescription()` to query package information.

This is measurably faster even when multiple package descriptions need to be read.

<details>
<summary>Simple benchmark</summary>

```r
bench::mark(
  `installed.packages()` = callr::r(\() installed.packages()[c('abind', 'zoo', 'nvimcom'), ]),
  `packageDescription()` = callr::r(\() lapply(c('abind', 'zoo', 'nvimcom'), packageDescription)),
  iterations = 5L,
  check = FALSE,
  memory = FALSE
)
```

```
  expression             median `itr/sec` total_time
1 installed.packages()    1.56s     0.445      8.98s
2 packageDescription() 447.54ms     2.14       2.33s
```

(Note that the actual numbers can vary quite drastically, based e.g. on the caching of the network storage. On some runs, a single invocation of `install.packages()` takes up to 5 seconds on my particular system!)
</details>

Since `installed.packages()` is called repeatedly in separate subprocesses, the overall effect of this PR should be a noticeable reduction of the startup time on some systems.

---

… unfortunately I was unable to actually test this PR for now, and I am asking for assistance with that: how do I create an installable, self-contained bundle that I can deploy in my local NeoVim such that it will install the bundled ‘nvimcom’ code, rather than taking the one from the current `master` branch release? Is it enough to use something like `{ url = "file:///local/path/to/Nvim-R", branch = "fix/faster-installed-check" }` with my NVim package manager?

I did try that, but I couldn’t get it running, and I believe this is at least partially caused by #769 (I’m running on the same cluster, with a very similar config, as @idavydov). After waiting for some time I *can* start the server but now R reports “package ‘nvimcom’ in options("defaultPackages") was not found”, even though `find.package()` finds it subsequently. Furthermore, I can manually remove the ‘nvimcom’ package from my R library, and Nvim-R automatically reinstalls it. However, when incrementing the package version I can see that the installed version of ‘nvimcom’ is not getting updated, it somehow keeps installing an *old* package version.