### PR TITLE
Use callout in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Nvim-R
 
 This is Nvim-R which improves Vim's support to edit R scripts.
-For Neovim users, this plugin was superseded by [R.nvim](https://github.com/R-nvim/R.nvim).
+
+> [!Note]
+> For Neovim users, this plugin is superseded by [R.nvim](https://github.com/R-nvim/R.nvim).
 
 ## Installation
 


### PR DESCRIPTION
This should hopefully draw a little more attention to the note that Nvim-R is superseded for Neovim users.