### PR TITLE
Fix bsd nvimcom

### DIFF
--- a/R/nvimcom/src/apps/nvimrserver.c
+++ b/R/nvimcom/src/apps/nvimrserver.c
@@ -7,7 +7,11 @@
 #include <string.h>     // String handling functions
 #include <sys/stat.h>   // Data returned by the stat() function
 #include <sys/types.h>  // Data types
+
+#ifdef __FreeBSD__
 #include <netinet/in.h> // BSD network library
+#endif
+
 #include <unistd.h>     // POSIX operating system API
 #ifdef WIN32
 #include <inttypes.h>

--- a/R/nvimcom/src/apps/nvimrserver.c
+++ b/R/nvimcom/src/apps/nvimrserver.c
@@ -1,13 +1,14 @@
-#include <ctype.h>     // Character type functions
-#include <dirent.h>    // Directory entry
-#include <signal.h>    // Signal handling
-#include <stdarg.h>    // Variable argument functions
-#include <stdio.h>     // Standard input/output definitions
-#include <stdlib.h>    // Standard library
-#include <string.h>    // String handling functions
-#include <sys/stat.h>  // Data returned by the stat() function
-#include <sys/types.h> // Data types
-#include <unistd.h>    // POSIX operating system API
+#include <ctype.h>      // Character type functions
+#include <dirent.h>     // Directory entry
+#include <signal.h>     // Signal handling
+#include <stdarg.h>     // Variable argument functions
+#include <stdio.h>      // Standard input/output definitions
+#include <stdlib.h>     // Standard library
+#include <string.h>     // String handling functions
+#include <sys/stat.h>   // Data returned by the stat() function
+#include <sys/types.h>  // Data types
+#include <netinet/in.h> // BSD network library
+#include <unistd.h>     // POSIX operating system API
 #ifdef WIN32
 #include <inttypes.h>
 #include <process.h>

--- a/R/nvimcom/src/nvimcom.c
+++ b/R/nvimcom/src/nvimcom.c
@@ -13,7 +13,11 @@
 #include <string.h>
 #include <sys/types.h>
 #include <time.h>
+
+#ifdef __FreeBSD__
 #include <netinet/in.h>
+#endif
+
 #include <unistd.h>
 
 #ifdef WIN32

--- a/R/nvimcom/src/nvimcom.c
+++ b/R/nvimcom/src/nvimcom.c
@@ -13,6 +13,7 @@
 #include <string.h>
 #include <sys/types.h>
 #include <time.h>
+#include <netinet/in.h>
 #include <unistd.h>
 
 #ifdef WIN32


### PR DESCRIPTION
This fix adds nvimcom compatibility to FreeBSD. Tested on FreeBSD 14.0. Should not interfere with other os's.