### PR TITLE
Partial fix for  #816

### DIFF
--- a/R/common_global.vim
+++ b/R/common_global.vim
@@ -572,8 +572,11 @@ function RCreateEditMaps()
         call RCreateCommentMaps()
     endif
     " Replace 'underline' with '<-'
-    if g:R_assign == 1 || g:R_assign == 2
+    if g:R_assign == 1 
         silent exe 'inoremap <buffer><silent> ' . g:R_assign_map . ' <Esc>:call ReplaceUnderS()<CR>a'
+    endif
+    if  g:R_assign == 2
+        silent exe 'inoremap <buffer><silent> ' . g:R_assign_map . g:R_assign_map . ' ' . g:R_assign_map . '<Esc>:call ReplaceUnderS()<CR>a'
     endif
 endfunction
 

--- a/R/common_global.vim
+++ b/R/common_global.vim
@@ -572,7 +572,7 @@ function RCreateEditMaps()
         call RCreateCommentMaps()
     endif
     " Replace 'underline' with '<-'
-    if g:R_assign == 1 
+    if g:R_assign == 1
         silent exe 'inoremap <buffer><silent> ' . g:R_assign_map . ' <Esc>:call ReplaceUnderS()<CR>a'
     endif
     if  g:R_assign == 2


### PR DESCRIPTION
Creates a separate trigger for `R_assign = 2` so that it doesn't drop out of insert mode unless two underscores (or `R_assign_map` characters) are typed. Consequently, inserts like "this_variable_name" will be correctly saved to the repeat register.

However the repeat register (`@.`) is still reset if a substitution is made. This will be harder to fix.