### PR TITLE
Correcting typo in R/gui_running.vim

### DIFF
--- a/R/gui_running.vim
+++ b/R/gui_running.vim
@@ -194,7 +194,7 @@ function MakeRMenu()
         menu R.Send.-Sep5- <nul>
         call RCreateMenuItem('ni', 'Send.Quarto\ render\ (cur\ file)', 'RQuartoRender', 'qr', ':call RQuarto("render")')
         call RCreateMenuItem('ni', 'Send.Quarto\ preview\ (cur\ file)', 'RQuartoPreview', 'qp', ':call RQuarto("preview")')
-        call RCreateMenuItem('ni', 'Send.Quarto\ stop\ preview\ (all\ files)', 'qs', ':call RQuarto("stop")')
+        call RCreateMenuItem('ni', 'Send.Quarto\ stop\ preview\ (all\ files)', 'RQuartoStop', 'qs', ':call RQuarto("stop")')
     endif
     "-------------------------------
     menu R.Send.-Sep6- <nul>


### PR DESCRIPTION
at line 197 in RCreateMenuItem function call the 3rd argument is missing. I guees the correct string here is 'RQuartoStop'.