### PR TITLE
Fixing non-API entry points in C code that trigger an error in R 4.6

### DIFF
--- a/R/vimcom/DESCRIPTION
+++ b/R/vimcom/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: vimcom
-Version: 0.9-168
-Date: 2025-08-08
+Version: 0.9-169
+Date: 2026-04-03
 Title: Intermediate the Communication Between R and Vim
 Author: Jakson Aquino
 Maintainer: Jakson Alves de Aquino <jalvesaq@gmail.com>

--- a/R/vimcom/src/vimcom.c
+++ b/R/vimcom/src/vimcom.c
@@ -669,7 +669,7 @@ static void vimcom_globalenv_list(void) {
     curdepth = 0;
 
 #if defined(R_VERSION) && R_VERSION >= R_Version(4, 6, 0)
-    PROTECT(envVarsSEXP = R_lsInternal3(R_GlobalEnv, allnames, FALSE));
+    PROTECT(envVarsSEXP = R_lsInternal3(R_GlobalEnv, allnames, TRUE));
 #else
     PROTECT(envVarsSEXP = R_lsInternal(R_GlobalEnv, allnames));
 #endif

--- a/R/vimcom/src/vimcom.c
+++ b/R/vimcom/src/vimcom.c
@@ -471,12 +471,12 @@ static char *vimcom_glbnv_line(SEXP *x, const char *xname, const char *curenv,
         p = vimcom_strcat(p, "\006{\006");
     } else if (Rf_isFactor(*x)) {
         p = vimcom_strcat(p, "\006!\006");
-    } else if (Rf_isValidString(*x)) {
+    } else if (Rf_isScalarString(*x)) {
         p = vimcom_strcat(p, "\006~\006");
     } else if (Rf_isFunction(*x)) {
         p = vimcom_strcat(p, "\006\003\006");
         xgroup = 1;
-    } else if (Rf_isFrame(*x)) {
+    } else if (Rf_isDataFrame(*x)) {
         p = vimcom_strcat(p, "\006$\006");
         xgroup = 2;
     } else if (Rf_isNewList(*x)) {
@@ -517,7 +517,7 @@ static char *vimcom_glbnv_line(SEXP *x, const char *xname, const char *curenv,
     SET_STRING_ELT(lablab, 0, mkChar("label"));
     PROTECT(txt = getAttrib(*x, lablab));
     if (length(txt) > 0) {
-        if (Rf_isValidString(txt)) {
+        if (Rf_isScalarString(txt)) {
             snprintf(buf, 159, "\006\006%s", CHAR(STRING_ELT(txt, 0)));
             escape_str(buf);
             p = vimcom_strcat(p, buf);
@@ -655,7 +655,7 @@ static void vimcom_globalenv_list(void) {
 
     curdepth = 0;
 
-    PROTECT(envVarsSEXP = R_lsInternal(R_GlobalEnv, allnames));
+    PROTECT(envVarsSEXP = R_lsInternal3(R_GlobalEnv, allnames, FALSE));
     for (int i = 0; i < Rf_length(envVarsSEXP); i++) {
         varName = CHAR(STRING_ELT(envVarsSEXP, i));
         if (R_BindingIsActive(Rf_install(varName), R_GlobalEnv)) {

--- a/R/vimcom/src/vimcom.c
+++ b/R/vimcom/src/vimcom.c
@@ -1,4 +1,5 @@
 #include <R.h> /* to include Rconfig.h */
+#include <Rversion.h>
 #include <Rdefines.h>
 #include <Rinternals.h>
 #include <R_ext/Parse.h>
@@ -471,12 +472,20 @@ static char *vimcom_glbnv_line(SEXP *x, const char *xname, const char *curenv,
         p = vimcom_strcat(p, "\006{\006");
     } else if (Rf_isFactor(*x)) {
         p = vimcom_strcat(p, "\006!\006");
+#if defined(R_VERSION) && R_VERSION >= R_Version(4, 6, 0)
     } else if (Rf_isScalarString(*x)) {
+#else
+    } else if (Rf_isValidString(*x)) {
+#endif
         p = vimcom_strcat(p, "\006~\006");
     } else if (Rf_isFunction(*x)) {
         p = vimcom_strcat(p, "\006\003\006");
         xgroup = 1;
+#if defined(R_VERSION) && R_VERSION >= R_Version(4, 6, 0)
     } else if (Rf_isDataFrame(*x)) {
+#else
+    } else if (Rf_isFrame(*x)) {
+#endif
         p = vimcom_strcat(p, "\006$\006");
         xgroup = 2;
     } else if (Rf_isNewList(*x)) {
@@ -517,7 +526,11 @@ static char *vimcom_glbnv_line(SEXP *x, const char *xname, const char *curenv,
     SET_STRING_ELT(lablab, 0, mkChar("label"));
     PROTECT(txt = getAttrib(*x, lablab));
     if (length(txt) > 0) {
+#if defined(R_VERSION) && R_VERSION >= R_Version(4, 6, 0)
         if (Rf_isScalarString(txt)) {
+#else
+        if (Rf_isValidString(txt)) {
+#endif
             snprintf(buf, 159, "\006\006%s", CHAR(STRING_ELT(txt, 0)));
             escape_str(buf);
             p = vimcom_strcat(p, buf);
@@ -655,7 +668,11 @@ static void vimcom_globalenv_list(void) {
 
     curdepth = 0;
 
+#if defined(R_VERSION) && R_VERSION >= R_Version(4, 6, 0)
     PROTECT(envVarsSEXP = R_lsInternal3(R_GlobalEnv, allnames, FALSE));
+#else
+    PROTECT(envVarsSEXP = R_lsInternal(R_GlobalEnv, allnames));
+#endif
     for (int i = 0; i < Rf_length(envVarsSEXP); i++) {
         varName = CHAR(STRING_ELT(envVarsSEXP, i));
         if (R_BindingIsActive(Rf_install(varName), R_GlobalEnv)) {


### PR DESCRIPTION
This PR fixes a few recently upgraded non-API entry points in C code that trigger an error in the forthcoming (April 24th) R 4.6 (see Section "Changes in R 4.6.0", subsection "C-Level Facilities" [here](https://cran.r-project.org/doc/manuals/r-devel/NEWS.html). Concretely:

* `Rf_isValidString()` has been replaced by `Rf_isScalarString()`
* `Rf_isFrame()` has been replaced by `Rf_isDataFrame()`
* `Rf_lsInternal()` has been replaced by `Rf_lsInternal3()`, which has a third additional argument to set whether the returned vector of character strings should be sorted or not. After looking at the R-devel source code, I decided to set it to `FALSE`.

I have tested it with both, the current release version of R 4.5.x and the current R-devel and forthcoming release R 4.6.0, and the fix seems to work fine with both versions.